### PR TITLE
Add default settings, that fix problems with the nginx-proxy

### DIFF
--- a/Templates/config.erb
+++ b/Templates/config.erb
@@ -65,6 +65,9 @@ $CFG->pathtosassc = '/usr/bin/sassc';
 $CFG->phpunit_prefix = 'phpu_';
 $CFG->phpunit_dataroot = $CFG->dataroot.'/phpunit/';
 
+// Setting to get the correct ip of the user instead of the ip of the nginx-proxy
+$CFG->getremoteaddrconf = 1;
+
 require_once(dirname(__FILE__) . '/lib/setup.php');
 
 // There is no php closing tag in this file,


### PR DESCRIPTION
Fixes the "Installation must be finished from the original IP address, sorry"-Error.

The setting causes the `$_SERVER['HTTP_CLIENT_IP']` field (if present) to be used to get the users ip, instead of `REMOTE_ADDR`, which holds the ip of the nginx-proxy.