### PR TITLE
XDebug: Start with request

### DIFF
--- a/Dockerfiles/php/php-7.4/Dockerfile
+++ b/Dockerfiles/php/php-7.4/Dockerfile
@@ -32,7 +32,7 @@ RUN yes | pecl install xdebug \
 	&& echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
 	&& echo 'xdebug.client_host=172.17.0.1' >> /usr/local/etc/php/conf.d/xdebug.ini \
 	&& echo 'xdebug.client_port=9000' >> /usr/local/etc/php/conf.d/xdebug.ini \
-	&& echo 'xdebug.start_upon_error=yes' >> /usr/local/etc/php/conf.d/xdebug.ini \
+	&& echo 'xdebug.start_with_request=yes' >> /usr/local/etc/php/conf.d/xdebug.ini \
 	&& echo 'xdebug.log_level=0' >> /usr/local/etc/php/conf.d/xdebug.ini
 
 

--- a/Dockerfiles/php/php-8.0/Dockerfile
+++ b/Dockerfiles/php/php-8.0/Dockerfile
@@ -33,7 +33,7 @@ RUN yes | pecl install xdebug \
 	&& echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
 	&& echo 'xdebug.client_host=172.17.0.1' >> /usr/local/etc/php/conf.d/xdebug.ini \
 	&& echo 'xdebug.client_port=9000' >> /usr/local/etc/php/conf.d/xdebug.ini \
-	&& echo 'xdebug.start_upon_error=yes' >> /usr/local/etc/php/conf.d/xdebug.ini \
+	&& echo 'xdebug.start_with_request=yes' >> /usr/local/etc/php/conf.d/xdebug.ini \
 	&& echo 'xdebug.log_level=0' >> /usr/local/etc/php/conf.d/xdebug.ini
 
 # Enable debugging of CLI scripts with IntelliJ (Hostname must match server name at ‘Project Settings | PHP | Servers’).


### PR DESCRIPTION
Previously, they were sometimes problems that the execution didn't halt at Breakpoints, when the server had not outputted anything yet.
In my limited testing, this didn't noticeably affect performance.

For this to work on old instances, the instances are needed to be rebuilt (`moodledocker refresh`).