### PR TITLE
Fix moodledocker exec / repoexec, escape parameters

### DIFF
--- a/Scripts/moodledocker
+++ b/Scripts/moodledocker
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'moodledocker-common.rb'
+require 'shellwords'
 
 # This is a simple wrapper in order to achieve easier aliases.
 
@@ -24,5 +25,4 @@ if !@scripts.include? scriptname then
 end
 
 # Replace current process with the actual script.
-# Note that parameters are not escaped...
-exec("#{MoodleDocker.base_dir}/Metafiles/Scripts/moodledocker-#{scriptname} #{ARGV.drop(1).join(" ")}")
+exec("#{MoodleDocker.base_dir}/Metafiles/Scripts/moodledocker-#{scriptname} #{ARGV.drop(1).map! { |o| Shellwords.escape(o)}.join(" ")}")

--- a/Scripts/moodledocker-exec
+++ b/Scripts/moodledocker-exec
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require_relative 'moodledocker-common.rb'
 require 'fileutils'
+require 'shellwords'
 
 def execute_on_docker(command)
   currentpath = Dir.pwd + "/."
@@ -20,7 +21,7 @@ def execute_on_docker(command)
 
   remotefolder = currentpath.gsub(projectpath,"/var/www/public/" + projectname + "/")
   puts "Executing command on #{servicename} ..."
-  system "docker exec -it #{servicename} bash -c '( cd #{remotefolder}; "+ command.join(' ') + ")'"
+  system "docker exec -it #{servicename} bash -c '( cd #{remotefolder}; "+ command.map! {|o| Shellwords.escape(o)}.join(' ') + ")'"
   return true
 end
 

--- a/Scripts/moodledocker-repoexec
+++ b/Scripts/moodledocker-repoexec
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require_relative 'moodledocker-common.rb'
 require 'fileutils'
+require 'shellwords'
 
 def execute_on_docker(command)
   currentpath = Dir.pwd + "/."
@@ -20,7 +21,7 @@ def execute_on_docker(command)
 
   remotefolder = "/var/www/public/" + projectname + "/"
   puts "Executing command in repository folder on #{servicename} ..."
-  system "docker exec -it #{servicename} bash -c '( cd #{remotefolder}; "+ command.join(' ') + ")'"
+  system "docker exec -it #{servicename} bash -c '( cd #{remotefolder}; "+  command.map! {|o| Shellwords.escape(o)}.join(' ') + ")'"
   return true
 end
 


### PR DESCRIPTION
Do _you_ sometimes want to call `admin/cli/scheduled_task.php` and need to escape your backslashes three times in order for the command to work? Well then this PR is for you! With this ***brand new*** pull request, instead of calling 
`mphp admin/cli/scheduled_task.php --execute='\\\\core\\\\task\\\\session_cleanup_task'` or even `mphp admin/cli/scheduled_task.php --execute=\\\\\\\\core\\\\\\\\task\\\\\\\\session_cleanup_task`, you can just invoke `mphp admin/cli/scheduled_task.php --execute='\core\task\session_cleanup_task'`. Wow!

----

This way, I _think_ `moodledocker exec <cmd>` should do the exact same as executing `<cmd>` inside the docker container directly.